### PR TITLE
fix: pass resolved graft path to search worker

### DIFF
--- a/bin/kb-search.sh
+++ b/bin/kb-search.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd -P)"
 VERIFY="$SCRIPT_DIR/kb_search_verify.py"
 [ -f "$VERIFY" ] || VERIFY="$HOME/knowledge-base/kb_search_verify.py"
 
-GRAFT="${GRAFT:-$(command -v graft 2>/dev/null || echo "$HOME/.local/bin/graft")}"
+export GRAFT="${GRAFT:-$(command -v graft 2>/dev/null || echo "$HOME/.local/bin/graft")}"
 
 print_results() {
 	[ -f "$VERIFY" ] || { echo "ERROR: verify script missing: $VERIFY"; exit 1; }

--- a/tests/fixtures/fake-graft.sh
+++ b/tests/fixtures/fake-graft.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf '%s\n' '{"hits":[{"pointer":"src/file.py:1","title":"Expected hit","score":1,"snippet":"example"}]}'

--- a/tests/kb-search.test.mjs
+++ b/tests/kb-search.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const shellTest = process.platform === "win32" ? test.skip : test;
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+shellTest("kb-search passes the resolved graft path to its Python worker", () => {
+  const home = mkdtempSync(join(tmpdir(), "heimdall-kb-search-"));
+  try {
+    const graft = join(home, ".local", "bin", "graft");
+    mkdirSync(dirname(graft), { recursive: true });
+    copyFileSync(join(repoRoot, "tests", "fixtures", "fake-graft.sh"), graft);
+    chmodSync(graft, 0o755);
+    mkdirSync(join(home, "Repos", "example", "graft"), { recursive: true });
+
+    const stdout = execFileSync("bash", [join(repoRoot, "bin", "kb-search.sh"), "example"], {
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, PATH: "/usr/bin:/bin", GRAFT: undefined },
+    });
+
+    assert.match(stdout, /Expected hit/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`kb-search.sh` resolves Graft to an absolute fallback path such as `~/.local/bin/graft`, but keeps that value as an unexported shell variable. The embedded Python worker reads `os.environ["GRAFT"]`; when the fallback binary is not on `PATH`, it instead tries bare `graft`, catches the resulting lookup failure, and silently returns no hits.

## Fix

Export the already-resolved `GRAFT` value before starting the Python worker. This keeps the shell preflight and the worker on the same executable.

A regression test runs the real search script with a fake Graft binary under `~/.local/bin`, deliberately excludes that directory from `PATH`, and asserts that the worker returns the fake hit.

## Validation

- WSL end-to-end regression fixture: failed before the change and passes after it
- `npm run typecheck`: passes
- `npm test`: 178 pass, 18 fail, 5 skip on Windows; the 18 failures were present before this change and are Windows/platform assumptions (HOME handling, symlinks, `python3`, and Windows ESM paths). The repository currently documents macOS support and a Linux manual-daemon fallback; GitHub CI runs on Ubuntu.