### PR TITLE
0.6.2: Mnemosyne as configurable retrieval backend (graft stays default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ heimdall search "excel tracker portfolio optimization"
 
 On macOS the backend runs as the launchd job `com.graft.daemon` (template: `launchd/com.heimdall.backend.plist.example`).
 
+### Alternative backend: Mnemosyne
+
+Ranked search also supports [mnemosyne-oss](https://github.com/mnemosyne-oss/mnemosyne) (SQLite-backed agent memory) as the retrieval backend. Graft remains the zero-config default; select mnemosyne per-invocation or persistently:
+
+```bash
+pip install mnemosyne-memory            # or: uv pip install mnemosyne-memory
+HEIMDALL_BACKEND=mnemosyne heimdall search "preferences"        # one-off
+# persistent:
+python3 -c 'import json,pathlib; p=pathlib.Path.home()/".heimdall/config.json"; c=json.loads(p.read_text()) if p.exists() else {}; c["backend"]="mnemosyne"; p.write_text(json.dumps(c,indent=2))'
+heimdall search "preferences"
+```
+
+Resolution order: `$HEIMDALL_BACKEND` > `~/.heimdall/config.json` `backend` key > `graft`. Pin a non-PATH binary with `MNEMOSYNE=/path/to/mnemosyne`. Mnemosyne results flow through the same ranked/verified output as graft hits.
+
 ## Demo
 
 ![Heimdall demo](assets/demo.gif)

--- a/bin/kb-search.sh
+++ b/bin/kb-search.sh
@@ -58,7 +58,11 @@ try:
     out = subprocess.run([mnemo, "recall", q, str(n), "--json"],
                          capture_output=True, text=True, timeout=90).stdout
     data = json.loads(out)
-    for r in data.get("results", []):
+except Exception as e:
+    print(f"WARN: mnemosyne recall failed: {e}", file=sys.stderr)
+    data = {}
+for r in (data.get("results") or []):
+    try:
         content = str(r.get("content", ""))
         # Home-anchored paths in the content drive the same verdict logic as
         # graft hits; memories without paths still rank via title coverage.
@@ -71,8 +75,8 @@ try:
             "body": f"memory [{path or 'no-path'}] {content}",
             "path": os.path.expanduser(path) if path else "/nonexistent-mnemosyne-memory",
         })
-except Exception as e:
-    print(f"WARN: mnemosyne recall failed: {e}", file=sys.stderr)
+    except (TypeError, ValueError) as e:
+        print(f"WARN: skipping malformed memory result: {e}", file=sys.stderr)
 q_toks = set(q.lower().split())
 for i, r in enumerate(sorted(results, key=lambda x: -x["score"])[:n], 1):
     p = r["path"]

--- a/extensions/kb-search-guard.ts
+++ b/extensions/kb-search-guard.ts
@@ -11,7 +11,7 @@
  * leaves tool results untouched.
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createGuard, GREP_TOOLS, RESET_TOOLS } from "./lib/kb-guard-core.mjs";
+import { createGuard, GREP_TOOLS, RESET_TOOLS, BLOCK_REASON } from "./lib/kb-guard-core.mjs";
 
 export default function kbSearchGuardExtension(pi: ExtensionAPI): void {
   const guard = createGuard();
@@ -23,9 +23,12 @@ export default function kbSearchGuardExtension(pi: ExtensionAPI): void {
     // feeding there would double-count). String verdicts = warn/escalate,
     // stashed and delivered on tool_result. Object verdicts = block, acted
     // on here — tool_call is the only hook that can block.
-    const v = guard.note(event.toolName, event.input as Record<string, unknown>);
-    if (v && typeof v === "object" && v.block === true) {
-      return { block: true, reason: v.reason };
+    const v: string | { block?: boolean; reason?: string } | null = guard.note(
+      event.toolName,
+      event.input as Record<string, unknown>,
+    );
+    if (v !== null && typeof v === "object" && v.block === true) {
+      return { block: true, reason: v.reason ?? BLOCK_REASON };
     }
     if (typeof v === "string") pending = v;
   });

--- a/extensions/lib/kb-guard-core.d.mts
+++ b/extensions/lib/kb-guard-core.d.mts
@@ -5,10 +5,19 @@ export const GREP_TOOLS: Set<string>;
 export const RESET_TOOLS: Set<string>;
 export const WARNING: string;
 export const ESCALATION: string;
+export const BLOCK_REASON: string;
+
+export interface BlockVerdict {
+  block: true;
+  reason: string;
+}
 
 export interface Guard {
-  note(toolName: string, input: Record<string, unknown>): string | null;
+  note(toolName: string, input: Record<string, unknown>): string | BlockVerdict | null;
   readonly chain: number;
 }
 
 export function createGuard(): Guard;
+
+/** True when any pipe/chain segment of the command leads with a search binary. */
+export function isSearchHead(command: string | undefined): boolean;

--- a/extensions/lib/kb-guard-core.mjs
+++ b/extensions/lib/kb-guard-core.mjs
@@ -32,7 +32,9 @@ export const BLOCK_REASON =
   "(it resets this guard), then retry the search.";
 
 /** Bash command where ANY pipe/chain segment leads with a file-search binary.
- * Covers `rg x .`, `cat f | grep x`, `echo hi && ls`. Path prefixes ok. */
+ * Covers `rg x .`, `cat f | grep x`, `echo hi && ls`. Path prefixes ok.
+ * ponytail: misses env-prefix (`FOO=1 rg`) and wrappers (`timeout 60 rg`);
+ * nudge guard, not adversarial security — extend regex if that matters. */
 export function isSearchHead(command) {
   const segs = String(command ?? "").split(/\|\||\||&&|;|\n/);
   return segs.some((s) => {
@@ -51,20 +53,25 @@ export function createGuard() {
   let chain = 0;
   let firings = 0; // total warnings fired this session — drives escalation
   return {
-    /** Feed one tool call. Returns warning string, block verdict {block,reason}, else null. */
+    /** Feed one tool call. Returns warning string, block verdict {block,reason}, else null.
+     * Resets are clean-slate: chain AND firings cleared — consulting knowledge
+     * de-escalates fully; a stale bad stretch can't prime later blocks. */
     note(toolName, input) {
       if (RESET_TOOLS.has(toolName)) {
         chain = 0;
+        firings = 0;
         return null;
       }
       if (toolName === "bash") {
         const cmd = String(input?.command ?? "");
         if (/(^|[;&\s])\s*(graft|heimdall)\b/.test(cmd)) {
           chain = 0;
+          firings = 0;
           return null;
         }
-        // bash counts as a grep-style action (it's how most searches run), but only
-        // search-headed bash is ever BLOCKABLE — npm test / echo must pass through.
+        // Past escalation, only SEARCH-headed bash matters: other bash neither
+        // fires nor advances the chain (stays "search actions since reset").
+        if (firings >= 2 && !isSearchHead(cmd)) return null;
         chain += 1;
         if (chain >= 3 && (firings < 2 || isSearchHead(cmd))) {
           firings += 1;

--- a/mise.toml
+++ b/mise.toml
@@ -8,3 +8,6 @@ run = "npx tsc --noEmit"
 
 [tasks.bench-test]
 run = "~/.heimdall/venv/bin/python3 -m pytest bench/tests -q"
+
+[tools]
+bun = "1.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heimdall",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heimdall",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typebox": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arihantdeva/heimdall",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Verified, self-healing knowledge layer for AI coding agents: cross-repo memory with trust verdicts, zero-token CPU-only indexing, hybrid retrieval",
   "license": "MIT",
   "keywords": [

--- a/tests/guard.test.mjs
+++ b/tests/guard.test.mjs
@@ -153,6 +153,13 @@ t("BLOCK8: search binary anywhere in pipe/chain segment is blockable", () => {
   assert.equal(g.note("bash", { command: "npm test 2>&1 | tail -5" }), null); // no search head
 });
 
+t("BLOCK7: graft/heimdall bash prefix still resets", () => {
+  const g = createGuard();
+  for (let i = 0; i < 7; i++) g.note("read", {});
+  assert.equal(g.note("bash", { command: "graft status" }), null);
+  assert.equal(g.note("bash", { command: "heimdall doctor" }), null);
+});
+
 t("BLOCK5: grep/ls/find-headed bash blocked too", () => {
   const g = blockReady();
   assert.equal(g.note("bash", { command: "/usr/bin/grep -rn x ." }).block, true);
@@ -167,9 +174,19 @@ t("BLOCK6: kb_search reset clears block state", () => {
   assert.equal(g.note("read", {}), null); // fresh chain — no warning, no block
 });
 
-t("BLOCK7: graft/heimdall bash prefix still resets", () => {
+t("BLOCK10: kb_sync reset clears block state identically", () => {
   const g = createGuard();
   for (let i = 0; i < 7; i++) g.note("read", {});
-  assert.equal(g.note("bash", { command: "graft status" }), null);
-  assert.equal(g.note("bash", { command: "heimdall doctor" }), null);
+  assert.equal(g.note("kb_sync", {}), null); // reset signal
+  assert.equal(g.note("find", {}), null); // fresh chain — no warning, no block
+  g.note("read", {});
+  const w = g.note("read", {}); // chain back at 3 → firing 1 again
+  assert.equal(typeof w, "string");
+  assert.ok(w.includes("⚠️")); // ladder restarted from warn, not block
+});
+
+t("BLOCK9: non-search bash at block stage neither fires nor advances chain", () => {
+  const g = blockReady();
+  assert.equal(g.note("bash", { command: "npm test" }), null);
+  assert.equal(g.chain, 6); // unchanged — chain counts search actions only
 });


### PR DESCRIPTION
## What
Adds mnemosyne-oss as a pluggable retrieval backend for `heimdall search` / MCP `kb_search`. @nanonets/graft remains the zero-config default.

## Backend resolution
1. `HEIMDALL_BACKEND` env var
2. `~/.heimdall/config.json` key `backend`
3. default: `graft`

```bash
uv pip install mnemosyne-memory
HEIMDALL_BACKEND=mnemosyne heimdall search "preferences"
MNEMOSYNE=/path/to/mnemosyne ...   # pin non-PATH binary
```

Mnemosyne hits (`recall <q> <n> --json`) map into the same ranked/verified output (STRONG/WEAK/NOPATH + coverage) as graft hits; missing binary exits 0 with install guidance (never an MCP isError). Per-result fault isolation: one malformed memory can't drop the whole result set.

## Also carries
- kb-guard block-verdict type fix (`.d.mts`/`ts`) so `tsc --noEmit` passes against the hardened guard API
- guard-core firings-reset + search-head-only post-escalation (from parallel hardening, verified green here)
- README backend section

## Verification
- `npm test`: 229 pass / 0 fail (includes 4 kb-search backend tests: default=graft, mnemosyne routing, missing-binary exit 0, graft passthrough)
- `tsc --noEmit`: clean
- Real-binary smoke: recall → ranked output, exit 0