### PR TITLE
feat(guard): agent-callable kb_guard_pause — suspend enforcement for N turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,32 @@ One call. Verified paths. Straight to work.
 
 ## How it compares
 
-| | **Heimdall** | mem0 | Claude Memory | Letta (MemGPT) | cAST / grep |
-|---|---|---|---|---|---|
-| Scope | **All your repos, one graph** | per-app/per-user | per-conversation/account | per-agent | per-repo |
-| Runs on CPU only | **yes** | cloud or self-host | cloud | self-host | yes |
-| Token cost of indexing | **zero** (tree-sitter + local embeddings) | LLM extraction | LLM summarization | LLM | zero but manual |
-| Trust verdicts on results | **STRONG / WEAK / REBUILT / STALE** | none | none | none | none |
-| Self-healing (moved files re-anchored) | **yes** | no | no | no | no |
-| Harness integrations | pi, Claude Code, Codex, Cursor, Windsurf | SDK/API | Claude products | SDK/API | editor plugins |
-| Local-first, your data stays home | **yes** | optional | no | yes | yes |
+Architecture-level comparison of shipped defaults — not benchmark claims. "LLM extraction" etc. describe each project's default pipeline as documented; self-hosted or configured-differently deployments vary.
+
+| | **Heimdall** | mem0 | Zep (Graphiti) | Letta (MemGPT) | LangMem / LangChain Memory | Vector-DB RAG | Claude Memory | cAST / grep |
+|---|---|---|---|---|---|---|---|---|
+| Scope | **All your repos, one graph** | per-app/per-user memories | per-user/session graph | per-agent | per-app/thread | per-corpus/index | per-conversation/account | per-repo |
+| Runs on CPU only | **yes** | LLM+embeddings in the loop | LLM extraction for entities/edges | LLM-in-the-loop memory management | LLM extraction + embeddings | embeddings (GPU-friendly) | cloud | yes |
+| Token cost of indexing | **zero** (tree-sitter + local embeddings) | LLM extraction per memory op | LLM calls per episode | LLM calls throughout | LLM extraction per write | embedding tokens only | LLM summarization | zero but manual |
+| Trust verdicts on results | **STRONG / WEAK / REBUILT / STALE** | none | none | none | none | similarity score only | none | none |
+| Self-healing (moved files re-anchored) | **yes** | no | no | no | no | no (stale chunks rank) | no | no |
+| Convergent state (idempotent re-index) | **yes** (level-triggered reconciler) | append-oriented | event-sourced episodes | conversation-scoped | append-oriented | re-ingest to update | opaque | n/a |
+| Reads private source locally | **yes, never leaves disk** | sent to extraction LLM | sent to extraction LLM | stays local w/ local models | sent to extraction LLM | local if self-hosted | cloud | yes |
+| Harness integrations | pi, Claude Code, Codex, Cursor, Windsurf | SDK/API | SDK/API + Graphiti | SDK/API | LangChain-native | DIY per stack | Claude products | editor plugins |
+
+### Where Heimdall beats mem0 and common RAG
+
+By design, not by benchmark — these follow from the architecture:
+
+1. **Zero-LLM indexing vs extraction pipelines.** mem0, Zep, Letta, and LangMem all put an LLM inside the write path: every remembered fact costs extraction tokens, adds latency, and means your code/notes are processed by (or prompt-built for) a hosted model unless you wire your own. Heimdall's ingest is tree-sitter plus local CPU embeddings — indexing 10k files costs $0 and leaks nothing.
+
+2. **Verified hits vs plausible hits.** RAG returns nearest neighbors with a similarity score; nothing checks that the chunk still exists, let alone that it answers the question. Heimdall re-verifies every result against the live filesystem at query time (path exists? content still matches?) and labels it STRONG/WEAK/REBUILT/STALE. Agents can act on STRONG without a confirmation round-trip.
+
+3. **Self-healing vs stale corpora.** In vector-RAG, a moved file leaves orphaned chunks ranking forever until someone re-runs ingestion. Heimdall's level-triggered reconciler converges: moved files re-anchor automatically (REBUILT), deletions retract exactly their own nodes, and re-indexing twice is identical to once.
+
+4. **Cross-repo scope without a corpus pipeline.** Classic RAG needs you to define, chunk, and refresh a corpus per app. Heimdall watches working trees continuously — new repos join the graph on their own, and personal context (prompt logs, notes, now even email via `heimdall ingest-email`) lands in the same graph your code lives in.
+
+5. **What they win back.** Fair's fair: mem0/Zep/Letta excel at conversational fact curation across chat products, multi-user serving, and hosted APIs; LLM extraction summarizes messy prose better than regexes. Heimdall is the opposite bet — a single developer's machine-wide workspace where the unit of memory is verified file-level knowledge, not chat utterances.
 
 Heimdall is the only one built for the actual workflow: many repos, many months, one agent session at a time, on hardware you already own.
 
@@ -240,6 +257,7 @@ Extraction is tree-sitter AST parsing via a Python bridge, **not an LLM call**: 
 | **Pi extension: autosync** | `extensions/kb-autosync.ts` | hook that appends path hints — never writes the graph |
 | **Pi extension: orient** | `extensions/kb-orient.ts` | injects prior-work hits into the first user prompt of a session (2.5s cap, silent degrade) |
 | **Pi extension: guard** | `extensions/kb-search-guard.ts` + `extensions/lib/kb-guard-core.mjs` | warns after 3 consecutive grep-style actions without kb_search |
+| **Email ingestion** | `bin/lib/ingest-email.mjs` | mailbox → graft-style cards (read-only via cli-email `list`/`show`), idempotent; retrieval rides the semantic layer |
 | **Backends** | `vendor/graft/` (Apache 2.0), `vendor/graphify/` (MIT) | Graft = semantic-memory daemon; graphify = code-graph extractors |
 
 **Backends are pluggable.** Any store speaking the graft CLI contract works; Graft is the vendored reference. See `docs/heimdall_compare.dot/png` for the graphify vs Graft vs Heimdall positioning (graphify answers *codebase* questions, Graft persists *notes/facts* across projects, Heimdall ties them together with trust verdicts and self-healing).

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Extraction is tree-sitter AST parsing via a Python bridge, **not an LLM call**: 
 | **Pi extension: tools** | `extensions/kb-tools.ts` | exposes `kb_search` / `kb_insert` / `kb_sync` as agent tools |
 | **Pi extension: autosync** | `extensions/kb-autosync.ts` | hook that appends path hints — never writes the graph |
 | **Pi extension: orient** | `extensions/kb-orient.ts` | injects prior-work hits into the first user prompt of a session (2.5s cap, silent degrade) |
-| **Pi extension: guard** | `extensions/kb-search-guard.ts` + `extensions/lib/kb-guard-core.mjs` | warns after 3 consecutive grep-style actions without kb_search |
+| **Pi extension: guard** | `extensions/kb-search-guard.ts` + `extensions/lib/kb-guard-core.mjs` | warns after 3 consecutive grep-style actions without kb_search; agent can self-suspend via the `kb_guard_pause` tool for 1–20 turns (enforcement resumes clean-slate on expiry) |
 | **Email ingestion** | `bin/lib/ingest-email.mjs` | mailbox → graft-style cards (read-only via cli-email `list`/`show`), idempotent; retrieval rides the semantic layer |
 | **Backends** | `vendor/graft/` (Apache 2.0), `vendor/graphify/` (MIT) | Graft = semantic-memory daemon; graphify = code-graph extractors |
 
@@ -337,7 +337,7 @@ npm run typecheck   # extensions typecheck
 
 Suites:
 - `tests/reconcile.test.mjs` — the point. Invariant tests: 40 racing writers converge to one node set; separate OS processes hinting one file collapse to one queue row; reconciling twice is byte-identical; ABA generation guard rejects stale commits; deletion retracts exactly its own nodes; cross-file edges converge regardless of reconcile order; depth clamping; parse-failure degrades to L1; audit catches behind-our-back edits incl. same-size-same-mtime rewrites (`--deep`); git checkout picked up (the old command-regex path could not see it); lock admits exactly one writer + stale-PID reclamation; node-id path namespacing; garbage hints dropped. The L3 end-to-end test self-skips without tree-sitter.
-- `tests/guard.test.mjs` — kb-search-guard contract (warn on 3rd consecutive grep action, reset on kb_search/kb_sync/graft, interleaved reads do NOT reset).
+- `tests/guard.test.mjs` — kb-search-guard contract (warn on 3rd consecutive grep action, reset on kb_search/kb_sync/graft, interleaved reads do NOT reset; agent-callable `suspend(N)`/`tickTurn()` pause: silences all enforcement for N model turns, clamped 1–20, expiry restores clean-slate).
 - `tests/init.test.mjs` + `tests/adapters.test.mjs` — CLI contract and per-harness config-writer smoke tests against temp HOMEs.
 - `tests/kb-verify.test.mjs` — content-aware verdict contract via `selftest:` node ids (no graft daemon needed): content mismatch downgrades STRONG, content match upgrades to STRONG, binary files degrade gracefully, `extract_paths` home-anchor regression (the tilde-form bug).
 

--- a/bin/embed-index.py
+++ b/bin/embed-index.py
@@ -25,8 +25,11 @@ from sentence_transformers import SentenceTransformer
 
 DB = pathlib.Path.home() / ".heimdall" / "global.db"
 REPOS = pathlib.Path.home() / "Repos"
-MODEL = "BAAI/bge-m3"
-DIM = 1024
+# bge-m3 weights are ~2.3GB; on a 16GB machine a query-time load can OOM the
+# system when several run in parallel. bge-small is 30x lighter and plenty for
+# card-title recall. Flip back to bge-m3 if recall quality measurably drops.
+MODEL = os.environ.get("HEIMDALL_EMBED_MODEL", "BAAI/bge-small-en-v1.5")
+DIM = 384 if "bge-small" in MODEL else 1024
 
 MODEL_CACHE: SentenceTransformer | None = None
 
@@ -102,7 +105,7 @@ def build() -> int:
     if stale:
         for cid, rid in stale:
             c.execute("DELETE FROM cards WHERE rowid=?", (rid,))
-    if stale or orphan_vec:
+    if stale or orphan_vec or _db_dim(c) != DIM:
         c.execute("DROP TABLE vec")
         c.execute(f"CREATE VIRTUAL TABLE vec USING vec0(embedding float[{DIM}] distance_metric=cosine)")
     B = 32
@@ -130,6 +133,9 @@ def build() -> int:
 
 def query(q: str, n: int = 5, related: bool = False) -> list[dict]:
     c = conn()
+    if DIM != _db_dim(c):
+        print("[]")  # ponytail: index still at old dim; rebuild (embed-index.py build) before semantic search works again
+        return []
     vec = model().encode(q, normalize_embeddings=True).tolist()
     rows = c.execute(
         "SELECT rowid, distance FROM vec WHERE embedding MATCH ? AND k = ?",
@@ -175,6 +181,18 @@ def query(q: str, n: int = 5, related: bool = False) -> list[dict]:
                                     "title": sibling.name, "score": 0.0, "related": True})
     c.close()
     return out
+
+
+def _db_dim(c: sqlite3.Connection) -> int:
+    row = c.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec'"
+    ).fetchone()
+    if not row or not row[0]:
+        return -1
+    import re
+
+    m = re.search(r"float\[(\d+)\]", row[0])
+    return int(m.group(1)) if m else -1
 
 
 def status() -> dict:

--- a/bin/embed-index.py
+++ b/bin/embed-index.py
@@ -18,18 +18,25 @@ import json
 import os
 import pathlib
 import sqlite3
+import subprocess
 import sys
+import fcntl
 
 import sqlite_vec
 from sentence_transformers import SentenceTransformer
 
 DB = pathlib.Path.home() / ".heimdall" / "global.db"
 REPOS = pathlib.Path.home() / "Repos"
-# bge-m3 weights are ~2.3GB; on a 16GB machine a query-time load can OOM the
-# system when several run in parallel. bge-small is 30x lighter and plenty for
-# card-title recall. Flip back to bge-m3 if recall quality measurably drops.
-MODEL = os.environ.get("HEIMDALL_EMBED_MODEL", "BAAI/bge-small-en-v1.5")
+# Heavy model is fine again — safeguards below stop parallel stacking:
+# single-flight lock + free-RAM gate. Set HEIMDALL_EMBED_MODEL=BAAI/bge-small-en-v1.5
+# (and rebuild) to drop query RSS from ~2.1GB to ~0.5GB.
+MODEL = os.environ.get("HEIMDALL_EMBED_MODEL", "BAAI/bge-m3")
 DIM = 384 if "bge-small" in MODEL else 1024
+
+# Safeguards (2026-08-25 halt): every invocation loads model weights fresh.
+# N parallel callers used to stack N × ~2GB and halt a 16GB machine.
+MIN_FREE_GB = float(os.environ.get("HEIMDALL_MIN_FREE_GB", "2"))
+BUILD_HEADROOM_GB = 4.0  # batch encode activations on top of weights
 
 MODEL_CACHE: SentenceTransformer | None = None
 
@@ -46,6 +53,55 @@ def conn() -> sqlite3.Connection:
     c.enable_load_extension(True)
     sqlite_vec.load(c)
     return c
+
+
+class Busy(Exception):
+    """Another embed-index process already holds the single-flight lock."""
+
+
+LOCK_PATH = pathlib.Path.home() / ".heimdall" / "embed-index.lock"
+
+
+def _acquire_lock():
+    """Nonblocking exclusive flock; raises Busy if someone else is mid-flight.
+    ponytail: handle intentionally never closed/released — this is a one-shot
+    CLI, the OS drops the lock at process exit."""
+    fh = open(LOCK_PATH, "w")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        fh.close()
+        raise Busy() from None
+    return fh
+
+
+def _free_ram_gb() -> float:
+    out = subprocess.run(["vm_stat"], capture_output=True, text=True).stdout
+    pages = {}
+    for line in out.splitlines():
+        key, _, val = line.partition(":")
+        val = val.strip().rstrip(".")
+        if val.isdigit():
+            pages[key.strip()] = int(val)
+    page = 16384 if "16384" in out.splitlines()[0] else 4096
+    free = (
+        pages.get("Pages free", 0)
+        + pages.get("Pages purgeable", 0)
+        + pages.get("Pages speculative", 0)
+    ) * page / 1e9
+    return free
+
+
+def _ram_ok(min_gb: float, what: str) -> bool:
+    free = _free_ram_gb()
+    if free >= min_gb:
+        return True
+    print(
+        f"embed-index: skipping {what} — {free:.1f}GB free RAM < {min_gb}GB "
+        "required for the heavy embed model. Retry when memory frees up.",
+        file=sys.stderr,
+    )
+    return False
 
 
 def init(c: sqlite3.Connection) -> None:
@@ -79,6 +135,13 @@ def cards_for(repo: pathlib.Path) -> list[tuple[str, str, str, str]]:
 
 
 def build() -> int:
+    try:
+        _acquire_lock()
+    except Busy:
+        print("embed-index: another instance is running; skipping build.", file=sys.stderr)
+        raise SystemExit(1)
+    if not _ram_ok(MIN_FREE_GB + BUILD_HEADROOM_GB, "build"):
+        raise SystemExit(1)
     c = conn()
     init(c)
     model_inst = model()
@@ -132,9 +195,26 @@ def build() -> int:
 
 
 def query(q: str, n: int = 5, related: bool = False) -> list[dict]:
+    global MODEL, DIM
     c = conn()
-    if DIM != _db_dim(c):
-        print("[]")  # ponytail: index still at old dim; rebuild (embed-index.py build) before semantic search works again
+    db_d = _db_dim(c)
+    if DIM != db_d:
+        # Index was built with another model (e.g. heavy rebuild gated on RAM
+        # while a lighter index exists). Adapt to the index so search keeps
+        # working; `build` is the only path that changes dims.
+        DIM = db_d
+        MODEL = "BAAI/bge-small-en-v1.5" if db_d == 384 else "BAAI/bge-m3"
+        if db_d < 0:
+            print("[]")  # ponytail: no vec table yet; run embed-index.py build
+            return []
+    try:
+        _acquire_lock()
+    except Busy:
+        # Degrade gracefully: kb-search.sh still has lexical hits. Only lines
+        # starting with '[' are consumed, so stderr notes are safe here.
+        print("embed-index: another instance holds the model; semantic layer skipped this call.", file=sys.stderr)
+        return []
+    if not _ram_ok(MIN_FREE_GB, "query"):
         return []
     vec = model().encode(q, normalize_embeddings=True).tolist()
     rows = c.execute(

--- a/bin/embed-index.py
+++ b/bin/embed-index.py
@@ -47,7 +47,10 @@ def conn() -> sqlite3.Connection:
 
 def init(c: sqlite3.Connection) -> None:
     c.execute("CREATE TABLE IF NOT EXISTS cards (id TEXT PRIMARY KEY, repo TEXT, path TEXT, title TEXT, body TEXT)")
-    c.execute(f"CREATE VIRTUAL TABLE IF NOT EXISTS vec USING vec0(embedding float[{DIM}])")
+    # distance_metric=cosine: vec0's default is L2, whose distance (sqrt(2-2cos))
+    # exceeds 1 and made `1 - distance` scores go negative while ranking stayed
+    # correct. v0.1.9 syntax: column-level `distance_metric=cosine` (no comma).
+    c.execute(f"CREATE VIRTUAL TABLE IF NOT EXISTS vec USING vec0(embedding float[{DIM}] distance_metric=cosine)")
 
 
 def cards_for(repo: pathlib.Path) -> list[tuple[str, str, str, str]]:
@@ -101,7 +104,7 @@ def build() -> int:
             c.execute("DELETE FROM cards WHERE rowid=?", (rid,))
     if stale or orphan_vec:
         c.execute("DROP TABLE vec")
-        c.execute(f"CREATE VIRTUAL TABLE vec USING vec0(embedding float[{DIM}])")
+        c.execute(f"CREATE VIRTUAL TABLE vec USING vec0(embedding float[{DIM}] distance_metric=cosine)")
     B = 32
     total = 0
     for i in range(0, len(all_cards), B):
@@ -111,6 +114,11 @@ def build() -> int:
             normalize_embeddings=True,
         )
         for (cid, repo_path, rel, title, body), vec in zip(batch, vecs):
+            # INSERT OR REPLACE moves the row (delete+insert) → NEW rowid when
+            # the id already existed; delete any vec rows for this card id's
+            # old rowids first so no orphan shadows k-NN with a dead vector.
+            c.execute("DELETE FROM vec WHERE rowid IN "
+                      "(SELECT rowid FROM cards WHERE id=?)", (cid,))
             c.execute("INSERT OR REPLACE INTO cards VALUES (?,?,?,?,?)", (cid, repo_path, rel, title, body))
             row = c.execute("SELECT rowid FROM cards WHERE id=?", (cid,)).fetchone()
             c.execute("DELETE FROM vec WHERE rowid=?", (row[0],))

--- a/extensions/kb-search-guard.ts
+++ b/extensions/kb-search-guard.ts
@@ -11,11 +11,48 @@
  * leaves tool results untouched.
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
 import { createGuard, GREP_TOOLS, RESET_TOOLS, BLOCK_REASON } from "./lib/kb-guard-core.mjs";
 
 export default function kbSearchGuardExtension(pi: ExtensionAPI): void {
   const guard = createGuard();
   let pending: string | null = null;
+
+  // Turn clock for agent-requested suspensions (kb_guard_pause): each model
+  // turn consumes one paused turn; expiry restores enforcement clean-slate.
+  // String-keyed overload — older stubs may not list turn_start in EventMap.
+  pi.on("turn_start", () => {
+    guard.tickTurn();
+  });
+
+  // Agent self-service escape hatch: suspend warn/escalate/block for N turns
+  // the AGENT chooses. Self-service only — nothing ever engages it automatically.
+  pi.registerTool({
+    name: "kb_guard_pause",
+    label: "KB Guard Pause",
+    description:
+      "Temporarily suspend Heimdall kb-guard warnings/escalations/blocks for N model turns " +
+      "(1–20, you choose). Use when doing legitimate heavy file exploration that the guard " +
+      "mis-fires on (deep refactors, bulk renames, log triage). Enforcement resumes " +
+      "automatically from a clean slate after N turns; re-calling extends the pause. " +
+      "Self-service: no approval needed.",
+    promptSnippet: "Pause kb-search-guard enforcement for N turns",
+    parameters: Type.Object({
+      turns: Type.Number({
+        description:
+          "How many model turns to stay suspended (1–20). Pick enough to finish the " +
+          "exploration burst that triggered the guard.",
+      }),
+    }),
+    async execute(_id, params) {
+      const applied = guard.suspend(params.turns);
+      const text =
+        applied > 0
+          ? `⏸️ kb-guard suspended for ${applied} turn(s). Warnings/escalations/blocks off; enforcement resumes automatically from a clean slate.`
+          : "kb_guard_pause: invalid turns (need a positive number, clamped to 20) — guard unchanged.";
+      return { content: [{ type: "text", text }], details: { pausedTurns: applied } };
+    },
+  });
 
   pi.on("tool_call", (event) => {
     if (typeof event.toolName !== "string") return;
@@ -57,4 +94,9 @@ if (import.meta.main) {
   console.log("3:", g.note("bash", { command: "ls" }));
   console.log("reset:", g.note("kb_search", {}));
   console.log("post:", g.note("find", {}));
+  console.log("pause:", g.suspend(2), "turns");
+  console.log("paused note:", g.note("read", {}));
+  g.tickTurn();
+  g.tickTurn();
+  console.log("post-pause chain:", g.chain, "firings:", g.firings);
 }

--- a/extensions/lib/kb-guard-core.d.mts
+++ b/extensions/lib/kb-guard-core.d.mts
@@ -14,7 +14,13 @@ export interface BlockVerdict {
 
 export interface Guard {
   note(toolName: string, input: Record<string, unknown>): string | BlockVerdict | null;
+  /** Suspend enforcement for N model turns (clamped 1–20; returns applied turns). */
+  suspend(turns: number): number;
+  /** Advance the turn clock; expires a lapsed pause with a clean slate. */
+  tickTurn(): void;
   readonly chain: number;
+  readonly firings: number;
+  readonly pausedTurns: number;
 }
 
 export function createGuard(): Guard;

--- a/extensions/lib/kb-guard-core.mjs
+++ b/extensions/lib/kb-guard-core.mjs
@@ -52,11 +52,39 @@ function consequence(firings) {
 export function createGuard() {
   let chain = 0;
   let firings = 0; // total warnings fired this session — drives escalation
+  let pausedTurns = 0; // >0: agent-requested suspension — note() always null
   return {
+    /** Suspend all enforcement for N model turns (agent self-service escape hatch).
+     * Returns turns actually applied (clamped to 1..20, floored; junk → 0 = no-op).
+     * Re-suspend takes the MAX, so a small second call never shortens a pause. */
+    suspend(turns) {
+      const n = Math.min(20, Math.floor(Number(turns)));
+      if (!Number.isFinite(n) || n < 1) return 0;
+      pausedTurns = Math.max(pausedTurns, n);
+      return pausedTurns;
+    },
+    /** Advance the turn clock by one model turn; expires a lapsed pause with a
+     * full clean slate — consulting knowledge de-escalates, same as kb_search. */
+    tickTurn() {
+      if (pausedTurns <= 0) return;
+      pausedTurns -= 1;
+      if (pausedTurns === 0) {
+        chain = 0;
+        firings = 0;
+      }
+    },
+    get pausedTurns() {
+      return pausedTurns;
+    },
+    get firings() {
+      return firings;
+    },
     /** Feed one tool call. Returns warning string, block verdict {block,reason}, else null.
+     * While suspended (agent-called kb_guard_pause), always null — full bypass.
      * Resets are clean-slate: chain AND firings cleared — consulting knowledge
      * de-escalates fully; a stale bad stretch can't prime later blocks. */
     note(toolName, input) {
+      if (pausedTurns > 0) return null; // suspension active — enforcement off
       if (RESET_TOOLS.has(toolName)) {
         chain = 0;
         firings = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arihantdeva/heimdall",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Verified, self-healing knowledge layer for AI coding agents: cross-repo memory with trust verdicts, zero-token CPU-only indexing, hybrid retrieval",
   "license": "MIT",
   "keywords": [

--- a/tests/guard.test.mjs
+++ b/tests/guard.test.mjs
@@ -190,3 +190,71 @@ t("BLOCK9: non-search bash at block stage neither fires nor advances chain", () 
   assert.equal(g.note("bash", { command: "npm test" }), null);
   assert.equal(g.chain, 6); // unchanged — chain counts search actions only
 });
+
+// ── Pause/suspend (2026-08-25): agent-callable temporary disable for N turns ──
+
+t("PAUSE1: suspend silences warnings entirely", () => {
+  const g = createGuard();
+  assert.equal(g.suspend(2), 2);
+  g.note("read", {});
+  g.note("read", {});
+  assert.equal(g.note("read", {}), null);
+  assert.equal(g.note("grep", {}), null);
+});
+
+t("PAUSE2: suspend prevents blocks even from a pre-fired ladder", () => {
+  const g = blockReady();
+  assert.equal(g.suspend(3), 3);
+  assert.equal(g.note("find", {}), null);
+  assert.equal(g.note("bash", { command: "ls -la" }), null);
+  assert.equal(g.note("bash", { command: "rg x ." }), null);
+});
+
+t("PAUSE3: turns above 20 clamp to 20", () => {
+  const g = createGuard();
+  assert.equal(g.suspend(500), 20);
+  assert.equal(g.pausedTurns, 20);
+});
+
+t("PAUSE4: non-positive/non-numeric turns rejected, fractions floored", () => {
+  const g = createGuard();
+  assert.equal(g.suspend(0), 0);
+  assert.equal(g.suspend(-3), 0);
+  assert.equal(g.suspend("abc"), 0);
+  assert.equal(g.suspend(NaN), 0);
+  assert.equal(g.suspend(2.9), 2);
+  assert.equal(g.pausedTurns, 2);
+});
+
+t("PAUSE5: expiry via tickTurn restores enforcement from clean slate", () => {
+  const g = createGuard();
+  g.suspend(1);
+  g.note("read", {});
+  g.note("read", {});
+  g.tickTurn(); // pause over
+  assert.equal(g.pausedTurns, 0);
+  assert.equal(g.chain, 0);
+  assert.equal(g.firings, 0);
+  g.note("read", {});
+  g.note("read", {});
+  const w = g.note("read", {}); // 3rd since expiry → firing 1 = warn, ladder restarted
+  assert.equal(typeof w, "string"); // warn again — ladder restarted, not block
+  assert.ok(w.includes("⚠️"));
+});
+
+t("PAUSE6: tickTurn is inert when not paused", () => {
+  const g = createGuard();
+  g.tickTurn();
+  g.note("read", {});
+  g.note("read", {});
+  assert.equal(typeof g.note("read", {}), "string");
+});
+
+t("PAUSE7: re-suspend extends rather than shrinks", () => {
+  const g = createGuard();
+  g.suspend(10);
+  g.suspend(2);
+  assert.equal(g.pausedTurns, 10);
+  g.suspend(15);
+  assert.equal(g.pausedTurns, 15);
+});


### PR DESCRIPTION
## Problem
The kb-search-guard ladder (warn → escalate → block) fires during legitimate heavy file exploration — deep refactors, bulk renames, log triage. Agents had no escape except calling kb_search for irrelevant queries to reset the chain.

## Fix
Self-service escape hatch, folded into the existing guard:

- **`kb_guard_pause` tool** (registered by `extensions/kb-search-guard.ts`): agent suspends all enforcement for N model turns it chooses (1–20). Re-calling extends (max-wins); nothing auto-engages it.
- **Core** (`kb-guard-core.mjs`): `suspend(turns)` + `tickTurn()` wired to pi's `turn_start`. While suspended, `note()` returns null — no warnings, escalations, or blocks. Expiry restores a clean slate (chain=0, firings=0), matching existing kb_search de-escalation semantics.
- Per-process state unchanged: restart clears suspension.

## Tests
7 new PAUSE cases in `tests/guard.test.mjs` (silence while paused, blocks suppressed from pre-fired ladder, clamp >20→20, junk/fractional input handling, expiry → warn-not-block on re-fire, inert tickTurn, extend-not-shrink). Suite: 28 guard tests / 250 repo-wide green; `tsc --noEmit` clean.