### PR TITLE
fix: make kb_insert durable and immediately searchable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If a PR breaks one of these invariants, the concurrency tests will go red — th
 
 ## Before opening a PR
 
-- `npm test` green (166+ tests)
+- `npm test` green (262 tests)
 - `npm run typecheck` clean
 - New behavior has a test
 - README updated if you changed user-facing behavior

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Heimdall is the only one built for the actual workflow: many repos, many months,
 
 **Does it work with my agent?** One command wires it into pi, Claude Code, Codex, Cursor, or Windsurf. Anything that can run a CLI can use `search`/`insert` directly.
 
-**Is it production-ready?** It runs daily on this author's machine across ~12,800 live nodes with a 166-test suite guarding the concurrency invariants. v0.2.0. LongMemEval benchmark harness is in `bench/` (in progress).
+**Is it production-ready?** It runs daily on this author's machine across ~12,800 live nodes with a 262-test suite guarding the concurrency invariants. v0.2.0. LongMemEval benchmark harness is in `bench/` (in progress).
 
 ## Roadmap
 
@@ -113,9 +113,10 @@ npm i -g @arihantdeva/heimdall
 heimdall init --harness claude-code   # or pi | codex | cursor | windsurf | all
 ```
 
-That's it for install + harness wiring (`init`, `insert` work immediately).
+That's it for install + harness wiring. `init`, `insert`, and searches over
+explicitly inserted memories work immediately.
 
-Ranked search and `doctor` need the [graft backend](https://github.com/NanoNets/Graft) — one extra step:
+Code-graph search and `doctor` need the [graft backend](https://github.com/NanoNets/Graft) — one extra step:
 
 ```bash
 # build graft from source, put the binary on PATH, then:
@@ -199,9 +200,13 @@ If Heimdall saved you a rebuild, a star helps other agents' humans find it.
                  ▼
         ~/.graft daemon (vendor/graft, built from source) — sqlite + bge-m3 embeddings + graph edges
 
+   EXPLICIT MEMORY WRITE (separate short-lived lock):
+   kb_insert / heimdall insert → atomic JSON record → ~/.heimdall/memories/mem-<uuid>.json
+
    SEARCH PATH (read side, no lock):
-   kb-search.sh → graft retrieve (hybrid ranked) → kb_search_verify.py (verdicts + stale heal)
-                → graft explore (graph walk of related work) → printed, ranked, verified
+   kb-search.sh → live manual-memory lexical search (always available)
+                + graft retrieval + optional global semantic index
+                → merged, ranked, filesystem-verified results
 ```
 
 **Core invariants** (each has a test):
@@ -248,6 +253,8 @@ Extraction is tree-sitter AST parsing via a Python bridge, **not an LLM call**: 
 | **Hints** | `bin/lib/hints.mjs` | the one channel a non-writer may use (append-only, atomic, torn-line tolerant) |
 | **Sink** | `bin/lib/sink.mjs` | projection targets: `GraftSink` (CLI) and `MemorySink` (tests/dry-run) |
 | **Ranked search** | `bin/kb-search.sh` | top-k hybrid ranked + graph walk, `--scope` filter |
+| **Explicit memory** | `bin/lib/manual-memory.mjs` | append-only atomic records + immediate lexical retrieval under `~/.heimdall/memories/` |
+| **Semantic index** | `bin/embed-index.py`, `bin/manual_memory_cards.py` | optional local embedding projection of Graft cards and explicit memories |
 | **Trust verification** | `bin/kb_search_verify.py` | content-aware STRONG/WEAK/STALE/REBUILT/REMOVED verdicts; stale self-heal |
 | **Stale pruning** | `bin/kb-stale-scan.py`, `bin/kb-rehome.sh` | full-graph sweep: deterministic rehome or log+delete |
 | **Health & telemetry** | `bin/kb-health.sh`, `bin/telemetry.sh` | daemon health, index freshness, usage stats (kb_* calls/24h, hit rate, est. time saved) |
@@ -294,10 +301,33 @@ Every adapter merges into existing config files (never clobbers your keys), is i
 heimdall search "excel tracker portfolio optimization"   # ranked + verified knowledge search
 heimdall insert --title "portfolio optimizer" \
   --body "~/work/quant-bot/src — EV-optimizer entry point" \
-  --keywords portfolio,optimize                              # record reusable work
+  --keywords portfolio,optimize --keywords decision          # record reusable work
 heimdall init --harness claude-code                      # wire into your harness (idempotent)
 heimdall doctor                                          # daemon + index health
 ```
+
+Successful insertion returns one JSON object suitable for CLI or MCP callers:
+
+```json
+{"id":"mem-5ab90a01-49a2-4e67-99aa-5365d912d984","path":"/home/me/.heimdall/memories/mem-5ab90a01-49a2-4e67-99aa-5365d912d984.json","title":"portfolio optimizer","searchable":true}
+```
+
+### Explicit memories
+
+`heimdall insert` preserves the supplied body verbatim in an immutable,
+machine-global JSON record at `~/.heimdall/memories/<mem-uuid>.json`. The
+originating absolute working directory is stored as provenance, not scope.
+Each record is written through a same-directory temporary file, flushed,
+atomically renamed, read back, and validated before success is returned. The
+memory directory is mode `0700` and records are mode `0600` on POSIX systems.
+Secret-shaped input is rejected without echoing the matched content.
+
+`heimdall search` reads these live files on every query and ranks matches in
+title, keywords, body, then originating path. This lexical lane works without
+Graft, repositories, Python embeddings, or `~/.heimdall/global.db`. A later
+`heimdall index` adds valid explicit memories to the local semantic index;
+insertion itself never waits for an embedding model. Records are append-only:
+this release intentionally provides no update or delete operation.
 
 Self-healing surface:
 
@@ -331,7 +361,7 @@ the card tree lives.
 ## Testing
 
 ```bash
-npm test            # full suite (166 tests)
+npm test            # full suite (262 tests)
 npm run typecheck   # extensions typecheck
 ```
 
@@ -349,7 +379,7 @@ The concurrency tests are the point: if the single-writer or idempotency propert
 - macOS today (launchd daemon management); Linux works with a manual daemon
 - tree-sitter-capable python for L2/L3 (`HEIMDALL_PYTHON` env, or `~/.heimdall/venv/bin/python3`, or `python3` in PATH)
 - Runtime npm deps: **zero** — `typebox`/`typescript`/`@types/node` are dev-only
-- Graft backend for `search`/`doctor` (built from `vendor/graft/`)
+- Graft backend for code-graph search and `doctor` (explicit-memory search needs no backend)
 
 ## Operations
 
@@ -376,7 +406,7 @@ MIT. Independent project — not affiliated with Graft or its authors.
 
 ## Runtime state
 
-- `~/.heimdall/` — journal, lock, hint queue, `config.json` (harness selection), adapter install records.
+- `~/.heimdall/` — journal, locks, hint queue, `config.json`, optional semantic index, and private append-only records under `memories/`.
 - `~/.graft/` — backend config (`config.yaml`), sqlite profile DB, `graftd.log`, `.last-sync` (sync-edits watermark).
 
 These are data, not build artifacts — never `rm`/`mv` over them blindly.

--- a/bin/embed-index.py
+++ b/bin/embed-index.py
@@ -24,6 +24,7 @@ import fcntl
 
 import sqlite_vec
 from sentence_transformers import SentenceTransformer
+from manual_memory_cards import memory_cards
 
 DB = pathlib.Path.home() / ".heimdall" / "global.db"
 REPOS = pathlib.Path.home() / "Repos"
@@ -76,20 +77,32 @@ def _acquire_lock():
 
 
 def _free_ram_gb() -> float:
-    out = subprocess.run(["vm_stat"], capture_output=True, text=True).stdout
-    pages = {}
-    for line in out.splitlines():
-        key, _, val = line.partition(":")
-        val = val.strip().rstrip(".")
-        if val.isdigit():
-            pages[key.strip()] = int(val)
-    page = 16384 if "16384" in out.splitlines()[0] else 4096
-    free = (
-        pages.get("Pages free", 0)
-        + pages.get("Pages purgeable", 0)
-        + pages.get("Pages speculative", 0)
-    ) * page / 1e9
-    return free
+    if sys.platform == "darwin":
+        out = subprocess.run(["vm_stat"], capture_output=True, text=True).stdout
+        lines = out.splitlines()
+        pages = {}
+        for line in lines:
+            key, _, val = line.partition(":")
+            val = val.strip().rstrip(".")
+            if val.isdigit():
+                pages[key.strip()] = int(val)
+        page = 16384 if lines and "16384" in lines[0] else 4096
+        return (
+            pages.get("Pages free", 0)
+            + pages.get("Pages purgeable", 0)
+            + pages.get("Pages speculative", 0)
+        ) * page / 1e9
+
+    meminfo = pathlib.Path("/proc/meminfo")
+    if meminfo.is_file():
+        fields = {}
+        for line in meminfo.read_text().splitlines():
+            key, _, value = line.partition(":")
+            fields[key] = value.strip().split()[0]
+        available_kib = int(fields.get("MemAvailable", fields.get("MemFree", "0")))
+        return available_kib * 1024 / 1e9
+
+    return 0.0
 
 
 def _ram_ok(min_gb: float, what: str) -> bool:
@@ -152,6 +165,7 @@ def build() -> int:
         if not repo.is_dir():
             continue
         all_cards.extend(cards_for(repo))
+    all_cards.extend(memory_cards())
     # Prune stale rows BEFORE embedding: cards removed from disk (e.g. mailbox
     # roll-off past the ingest limit, or a graft build regenerating graft/)
     # otherwise linger as vec orphans that pollute k-NN results with dead paths.

--- a/bin/kb-search.sh
+++ b/bin/kb-search.sh
@@ -98,12 +98,12 @@ print_results() {
 	[ -f "$VERIFY" ] || { echo "ERROR: verify script missing: $VERIFY"; exit 1; }
 	python3 "$VERIFY" "$1" "$2" "$SCOPE" "$N" "$Q"
 }
-echo "== retrieve (per-repo graft + global semantic): $Q"
+echo "== retrieve (manual memory + per-repo graft + global semantic): $Q"
 if [ ! -x "$GRAFT" ]; then
-	# Not a tool failure: a fresh/unconfigured machine has validly zero results.
-	# Exit 0 so callers (MCP kb_search) get an answer, not isError.
-	echo "WARN: graft binary not found at $GRAFT (set GRAFT=/path/to/graft). Install: npm i -g @nanonets/graft. Search unavailable until indexed — this is an empty result, not an error."
-	exit 0
+	echo "WARN: graft binary not found at $GRAFT (set GRAFT=/path/to/graft). Code-graph search is unavailable; manual-memory search remains active."
+	export HEIMDALL_GRAFT_AVAILABLE=0
+else
+	export HEIMDALL_GRAFT_AVAILABLE=1
 fi
 
 # Global semantic layer (bge-m3 embeddings over repo source).
@@ -125,13 +125,6 @@ else
 	fi
 fi
 
-if [ ${#REPO_LIST[@]} -eq 0 ]; then
-	# Fresh install / no indexed repos yet: valid empty answer (exit 0), with
-	# setup guidance in-band. Exit 1 here broke MCP kb_search (isError) on CI.
-	echo "No repos with a graft graph found under ~/Repos yet. Index one: cd <repo> && heimdall index (or graft build). Search returns no hits until then."
-	exit 0
-fi
-
 # Merge JSON hits from every repo into one JSON array shaped like graft
 # retrieve results: {result:{results:[{title,score,id_hex}]}} with paths.
 # PLUS global semantic hits from embed-index.py.
@@ -144,7 +137,7 @@ script_dir = sys.argv[3]
 repos = sys.argv[4:]
 graft = os.environ.get("GRAFT", "graft")
 results = []
-for repo in repos:
+for repo in (repos if os.environ.get("HEIMDALL_GRAFT_AVAILABLE") == "1" else []):
     try:
         out = subprocess.run([graft, "ask", q, repo, "--json", "-n", str(n)],
                              capture_output=True, text=True, timeout=60).stdout
@@ -163,6 +156,27 @@ for repo in repos:
             })
     except Exception:
         continue
+# Immediate machine-global memory lane. This reads canonical JSON records and
+# needs neither Graft nor the optional embedding environment.
+manual = os.path.join(script_dir, "manual-memory.js")
+try:
+    out = subprocess.run(["node", manual, "search", q, str(n)],
+                         capture_output=True, text=True, timeout=10).stdout
+    for h in json.loads(out).get("hits", []):
+        results.append({
+            "id_hex": h.get("id", "manual-?"),
+            "title": h.get("title", ""),
+            "score": 3.0 + min(float(h.get("score", 0)) / 10.0, 1.0),
+            "body": "\n".join([
+                h.get("body", ""),
+                "keywords: " + " ".join(h.get("keywords", [])),
+                "cwd: " + h.get("cwd", ""),
+            ]),
+            "path": h.get("path", ""),
+            "manual": True,
+        })
+except Exception as e:
+    print(f"WARN: manual-memory lane failed: {e}", file=sys.stderr)
 # Global semantic hits (bge-m3): append as top-ranked candidates.
 # embed-index.py lives next to kb-search.sh; the shell passes SCRIPT_DIR in
 # argv[3] because sys.argv[0] is "-" for stdin-invoked python.
@@ -209,6 +223,9 @@ seen = {}
 for r in sorted(results, key=lambda x: -x["score"]):
     seen.setdefault(r["title"], r)
 merged = sorted(seen.values(), key=lambda x: -x["score"])[:n]
+
+if not merged:
+    print("No knowledge hits. Manual memories are searched immediately; index a repo with `graft build` for code-graph results.")
 
 # Verdict pass: STRONG if path exists on disk + lexical coverage of query,
 # WEAK if path exists, NOPATH/STALE otherwise. (Replaces kb_search_verify.py,

--- a/bin/lib/cli-main.mjs
+++ b/bin/lib/cli-main.mjs
@@ -49,25 +49,21 @@ async function runInsert(args) {
     const i = args.indexOf(f);
     return i >= 0 ? args[i + 1] : "";
   };
+  const getAll = (f) => args.flatMap((arg, i) =>
+    arg === f && i + 1 < args.length ? [args[i + 1]] : []);
   const title = get("--title");
   const body = get("--body");
-  const kws = (get("--keywords") || "").split(",").filter(Boolean);
+  const kws = getAll("--keywords");
   if (!title || !body) {
     console.error("usage: heimdall insert --title T --body B [--keywords k1,k2]");
     return 1;
   }
-  // @nanonets/graft has no `insert` — the journal is authoritative and the
-  // per-repo graph is rebuilt by `graft build`. Record the intent in the
-  // journal (hint queue) so the reconciler picks it up. (No graft binary
-  // required for insert — journal-only.)
   try {
-    const { emitHint } = await import("./hints.mjs");
-    const { queueHintPath } = await import("./depth.mjs");
-    const hintFile = queueHintPath();
-    const target = join(process.cwd(), title.replace(/[^a-zA-Z0-9_.-]/g, "_") + ".fact.md");
-    emitHint(hintFile, target, "insert:" + title);
+    const { insertMemory } = await import("./manual-memory.mjs");
+    const stored = await insertMemory({ title, body, keywords: kws });
+    console.log(JSON.stringify(stored));
   } catch (e) {
-    console.error(`ERROR: hint failed: ${e.message?.split("\n")[0] ?? e}`);
+    console.error(`ERROR: insert failed: ${e.message?.split("\n")[0] ?? e}`);
     return 1;
   }
   return 0;

--- a/bin/lib/facts.mjs
+++ b/bin/lib/facts.mjs
@@ -24,7 +24,7 @@ const SECRET_RES = [
   /\b[A-Za-z0-9+/]{40,}={0,2}\b/,
 ];
 
-const isSecret = (s) => SECRET_RES.some((re) => re.test(s));
+export const containsSecret = (s) => SECRET_RES.some((re) => re.test(s));
 
 // Ordered fact patterns over one normalized utterance. First match wins kind,
 // so the order below IS the precedence: preferences outrank generic
@@ -62,8 +62,8 @@ function makeFact(kind, rawUtterance, path, line) {
 function extractFromLine(lineText, path, line, out, meta) {
   // Secret screen runs BEFORE pattern matching and before anything is pushed:
   // a secret-shaped line can never become a fact body (FC-09/FC-10).
-  if (!lineText.trim() || isSecret(lineText)) {
-    if (isSecret(lineText)) meta.skippedSecrets++;
+  if (!lineText.trim() || containsSecret(lineText)) {
+    if (containsSecret(lineText)) meta.skippedSecrets++;
     return;
   }
   const text = nfkc(lineText); // fold compat codepoints before matching

--- a/bin/lib/manual-memory.mjs
+++ b/bin/lib/manual-memory.mjs
@@ -1,0 +1,170 @@
+// manual-memory — immutable, machine-global records written by kb_insert.
+// The files are canonical; lexical and semantic indexes are rebuildable views.
+import {
+  chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync,
+  readdirSync, renameSync, unlinkSync, writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { containsSecret } from "./facts.mjs";
+import { Lock } from "./lock.mjs";
+
+export const MEMORY_SCHEMA = "heimdall.memory.v1";
+export const memoryDir = (home = homedir()) => join(home, ".heimdall", "memories");
+export const memoryLockPath = (home = homedir()) =>
+  join(home, ".heimdall", "manual-memory.lock");
+
+const ID_RE = /^mem-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const delay = (ms) => new Promise((done) => setTimeout(done, ms));
+const tokens = (s) =>
+  [...new Set(String(s ?? "").toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [])];
+
+function normalizedKeywords(values = []) {
+  const seen = new Set();
+  const out = [];
+  for (const value of values) {
+    for (const item of String(value).split(",")) {
+      const keyword = item.trim();
+      const key = keyword.toLocaleLowerCase();
+      if (keyword && !seen.has(key)) {
+        seen.add(key);
+        out.push(keyword);
+      }
+    }
+  }
+  return out;
+}
+
+function validRecord(record, path) {
+  return record?.schema === MEMORY_SCHEMA &&
+    typeof record.id === "string" && ID_RE.test(record.id) &&
+    (!path || basename(path) === `${record.id}.json`) &&
+    typeof record.title === "string" && record.title.trim().length > 0 &&
+    typeof record.body === "string" && record.body.trim().length > 0 &&
+    Array.isArray(record.keywords) &&
+    record.keywords.every((k) => typeof k === "string" && k.trim() === k && k.length > 0) &&
+    typeof record.createdAt === "string" && ISO_RE.test(record.createdAt) &&
+    typeof record.cwd === "string" && isAbsolute(record.cwd);
+}
+
+export function readMemory(path) {
+  try {
+    const record = JSON.parse(readFileSync(path, "utf8"));
+    return validRecord(record, path) ? record : null;
+  } catch {
+    return null;
+  }
+}
+
+function coverage(queryTokens, value) {
+  if (!queryTokens.length) return 0;
+  const haystack = new Set(tokens(value));
+  return queryTokens.filter((token) => haystack.has(token)).length / queryTokens.length;
+}
+
+function scoreRecord(record, query) {
+  const q = String(query ?? "").trim().toLocaleLowerCase();
+  const qTokens = tokens(q);
+  if (!q) return 0;
+  const keywordText = record.keywords.join(" ");
+  const idScore = coverage(qTokens, record.id);
+  const titleScore = coverage(qTokens, record.title);
+  const keywordScore = coverage(qTokens, keywordText);
+  const bodyScore = coverage(qTokens, record.body);
+  const cwdScore = coverage(qTokens, record.cwd);
+  const phrase = record.title.toLocaleLowerCase().includes(q) ? 2
+    : keywordText.toLocaleLowerCase().includes(q) ? 0.75
+      : record.body.toLocaleLowerCase().includes(q) ? 0.5
+        : record.cwd.toLocaleLowerCase().includes(q) ? 0.25 : 0;
+  const score = idScore * 5 + titleScore * 4 + keywordScore * 3 +
+    bodyScore * 2 + cwdScore + phrase;
+  return score > 0 ? score : 0;
+}
+
+export function searchMemories(query, { home = homedir(), limit = 6 } = {}) {
+  let names;
+  try {
+    names = readdirSync(memoryDir(home)).filter((name) => name.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const hits = [];
+  for (const name of names) {
+    const path = join(memoryDir(home), name);
+    const record = readMemory(path);
+    if (!record) continue;
+    const score = scoreRecord(record, query);
+    if (score > 0) hits.push({ ...record, path, score });
+  }
+  return hits
+    .sort((a, b) => b.score - a.score || b.createdAt.localeCompare(a.createdAt) ||
+      a.id.localeCompare(b.id))
+    .slice(0, Math.max(1, Number(limit) || 6));
+}
+
+async function withStoreLock(home, fn) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const result = await Lock.withLock(memoryLockPath(home), fn);
+    if (result !== null) return result;
+    await delay(Math.min(5 + attempt * 2, 50));
+  }
+  throw new Error("manual memory store is busy; retry kb_insert");
+}
+
+export async function insertMemory({
+  title, body, keywords = [], cwd = process.cwd(), home = homedir(),
+  now = () => new Date(), idFactory = randomUUID,
+}) {
+  if (typeof title !== "string" || !title.trim() ||
+      typeof body !== "string" || !body.trim()) {
+    throw new Error("title and body are required non-empty strings");
+  }
+  const cleanKeywords = normalizedKeywords(keywords);
+  if (containsSecret([title, body, ...cleanKeywords].join("\n"))) {
+    throw new Error("refusing to store secret-shaped content");
+  }
+  const id = `mem-${String(idFactory()).replace(/^mem-/, "")}`;
+  if (!ID_RE.test(id)) {
+    throw new Error("failed to allocate a valid manual memory id");
+  }
+  const record = {
+    schema: MEMORY_SCHEMA, id, title, body,
+    keywords: cleanKeywords, createdAt: now().toISOString(), cwd: resolve(cwd),
+  };
+  const path = await withStoreLock(home, () => {
+    const dir = memoryDir(home);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700);
+    const target = join(dir, `${id}.json`);
+    if (existsSync(target)) throw new Error("manual memory id already exists");
+    const temp = join(dir, `.${id}.${process.pid}.tmp`);
+    let fd = null;
+    try {
+      fd = openSync(temp, "wx", 0o600);
+      writeSync(fd, JSON.stringify(record, null, 2) + "\n", null, "utf8");
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = null;
+      renameSync(temp, target);
+      chmodSync(target, 0o600);
+      if (process.platform !== "win32") {
+        const dirFd = openSync(dir, "r");
+        try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
+      }
+      return target;
+    } finally {
+      if (fd !== null) try { closeSync(fd); } catch { /* already closed */ }
+      try { unlinkSync(temp); } catch { /* renamed or never created */ }
+    }
+  });
+  const reopened = readMemory(path);
+  if (!reopened || reopened.body !== body || reopened.id !== id) {
+    throw new Error("manual memory failed durable read-back verification");
+  }
+  const searchable = searchMemories(id, { home, limit: 1 }).some((hit) => hit.id === id);
+  if (!searchable) throw new Error("manual memory failed lexical search verification");
+  return { id, path, title, searchable: true };
+}

--- a/bin/lib/mcp-server.mjs
+++ b/bin/lib/mcp-server.mjs
@@ -72,12 +72,16 @@ function cli(args, { timeoutMs = 120_000 } = {}) {
 	return new Promise((resolve) => {
 		const child = spawn(process.execPath, [HEIMDALL_JS, ...args], { stdio: ["ignore", "pipe", "pipe"] });
 		let out = "";
+		let stderr = "";
 		const timer = setTimeout(() => child.kill(), timeoutMs);
 		child.stdout.on("data", (d) => { out += d; });
-		child.stderr.on("data", () => {});
+		child.stderr.on("data", (d) => { stderr += d; });
 		child.on("close", (code) => {
 			clearTimeout(timer);
-			resolve({ code: code ?? 1, text: out.trim() || "(no output)" });
+			const text = code === 0
+				? out.trim() || stderr.trim() || "(no output)"
+				: [out.trim(), stderr.trim()].filter(Boolean).join("\n") || "(no output)";
+			resolve({ code: code ?? 1, text });
 		});
 		child.on("error", (err) => {
 			clearTimeout(timer);

--- a/bin/manual-memory.js
+++ b/bin/manual-memory.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Internal JSON bridge used by kb-search.sh for the immediate memory lane.
+import { searchMemories } from "./lib/manual-memory.mjs";
+
+const [command, query = "", limit = "6"] = process.argv.slice(2);
+if (command !== "search" || !query.trim()) {
+  console.error("usage: manual-memory.js search <query> [limit]");
+  process.exitCode = 2;
+} else {
+  const hits = searchMemories(query, { limit: Math.max(1, Number(limit) || 6) });
+  process.stdout.write(JSON.stringify({ hits }) + "\n");
+}

--- a/bin/manual_memory_cards.py
+++ b/bin/manual_memory_cards.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Read canonical manual-memory JSON as embed-index card tuples."""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from typing import List, Optional, Tuple
+
+SCHEMA = "heimdall.memory.v1"
+
+
+def _valid(record: object, path: pathlib.Path) -> bool:
+    return (
+        isinstance(record, dict)
+        and record.get("schema") == SCHEMA
+        and isinstance(record.get("id"), str)
+        and bool(re.fullmatch(
+            r"mem-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+            record["id"],
+            re.IGNORECASE,
+        ))
+        and path.name == record["id"] + ".json"
+        and isinstance(record.get("title"), str)
+        and bool(record["title"].strip())
+        and isinstance(record.get("body"), str)
+        and bool(record["body"].strip())
+        and isinstance(record.get("keywords"), list)
+        and all(isinstance(k, str) and bool(k) and k.strip() == k for k in record["keywords"])
+        and isinstance(record.get("createdAt"), str)
+        and bool(re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", record["createdAt"]))
+        and isinstance(record.get("cwd"), str)
+        and pathlib.Path(record["cwd"]).is_absolute()
+    )
+
+
+def memory_cards(
+    home: Optional[pathlib.Path] = None,
+) -> List[Tuple[str, str, str, str, str]]:
+    root = (home or pathlib.Path.home()) / ".heimdall" / "memories"
+    cards = []
+    if not root.is_dir():
+        return cards
+    for path in sorted(root.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        if not _valid(record, path):
+            continue
+        context = "\n".join([
+            record["body"],
+            "keywords: " + " ".join(record["keywords"]),
+            "cwd: " + record["cwd"],
+        ])
+        cards.append(
+            (f"memory:{record['id']}", root.as_posix(), path.name, record["title"], context)
+        )
+    return cards
+
+
+if __name__ == "__main__":
+    print(json.dumps(memory_cards()))

--- a/tests/cli-contract.test.mjs
+++ b/tests/cli-contract.test.mjs
@@ -6,7 +6,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import {
+  existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -58,6 +60,34 @@ test("F3: hint on nonexistent path warns but still exits 0 (hint is advisory)", 
   assert.equal(r.status, 0, "hint stays advisory — absent is reconciled later");
   assert.match((r.stderr ?? "") + (r.stdout ?? ""), /does not exist|not found/i,
     "user must be told the path is missing");
+});
+
+test("insert persists exact content and normalizes comma/repeated keywords", () => {
+  const home = mkdtempSync(join(tmpdir(), "heimdall-cli-insert-"));
+  const cwd = mkdtempSync(join(tmpdir(), "heimdall-cli-cwd-"));
+  try {
+    const body = "Exact first line.\nExact second line: café λ.\n";
+    const r = spawnSync(process.execPath, [
+      CLI, "insert", "--title", "CLI durable memory", "--body", body,
+      "--keywords", "zircon,precedence", "--keywords", "Precedence", "--keywords", "durable",
+    ], {
+      cwd, encoding: "utf8", timeout: 30_000,
+      env: { ...process.env, HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const result = JSON.parse(r.stdout);
+    assert.equal(result.searchable, true);
+    assert.ok(result.id.startsWith("mem-"));
+    assert.equal(existsSync(result.path), true);
+    const record = JSON.parse(readFileSync(result.path, "utf8"));
+    assert.equal(record.body, body);
+    assert.deepEqual(record.keywords, ["zircon", "precedence", "durable"]);
+    assert.equal(record.cwd, cwd);
+    assert.equal(existsSync(join(home, ".heimdall", "hints.jsonl")), false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 // ── facts-cli.mjs: bench ingest contract (spec D3/D6) ────────────────────────

--- a/tests/kb-search.test.mjs
+++ b/tests/kb-search.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { insertMemory } from "../bin/lib/manual-memory.mjs";
+
 const shellTest = process.platform === "win32" ? test.skip : test;
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -45,6 +47,34 @@ shellTest("kb-search defaults to the graft backend with zero config", () => {
 
     assert.match(stdout, /GraftRan/);
     assert.doesNotMatch(stdout, /Mnemo hit/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+shellTest("kb-search finds manual title, body, and keyword without any backend", async () => {
+  const home = mkdtempSync(join(tmpdir(), "heimdall-manual-search-"));
+  try {
+    const stored = await insertMemory({
+      title: "Zircon-title procedure",
+      body: "Use occurrence-scoped steps with acyclic-body ordering.",
+      keywords: ["precedence-keyword"],
+      cwd: "/work/modeling",
+      home,
+    });
+    for (const query of ["zircon-title", "acyclic-body", "precedence-keyword"]) {
+      const result = spawnSync("bash", [join(repoRoot, "bin", "kb-search.sh"), query], {
+        encoding: "utf8",
+        env: {
+          ...process.env, HOME: home, PATH: "/usr/bin:/bin",
+          GRAFT: "/nonexistent/graft", HEIMDALL_REPOS: "",
+        },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /Zircon-title procedure/);
+      assert.match(result.stdout, /\[STRONG\]/);
+      assert.match(result.stdout, new RegExp(stored.id));
+    }
   } finally {
     rmSync(home, { recursive: true, force: true });
   }

--- a/tests/manual-memory.test.mjs
+++ b/tests/manual-memory.test.mjs
@@ -1,0 +1,197 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync,
+  readdirSync, rmSync, statSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { Lock } from "../bin/lib/lock.mjs";
+import {
+  MEMORY_SCHEMA,
+  insertMemory,
+  memoryDir,
+  memoryLockPath,
+  readMemory,
+  searchMemories,
+} from "../bin/lib/manual-memory.mjs";
+
+function sandbox() {
+  const home = mkdtempSync(join(tmpdir(), "heimdall-memory-"));
+  return { home, clean: () => rmSync(home, { recursive: true, force: true }) };
+}
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("manual memory: atomic insert preserves the exact record and permissions", async () => {
+  const s = sandbox();
+  try {
+    const body = "First line.\nUnicode survives: café λ.\n";
+    const result = await insertMemory({
+      title: "Durable title",
+      body,
+      keywords: ["ORM", "modeling"],
+      cwd: "/work/one",
+      home: s.home,
+      now: () => new Date("2026-08-25T12:00:00.000Z"),
+      idFactory: () => "00000000-0000-4000-8000-000000000001",
+    });
+
+    assert.deepEqual(result, {
+      id: "mem-00000000-0000-4000-8000-000000000001",
+      path: join(memoryDir(s.home), "mem-00000000-0000-4000-8000-000000000001.json"),
+      title: "Durable title",
+      searchable: true,
+    });
+    assert.deepEqual(readMemory(result.path), {
+      schema: MEMORY_SCHEMA,
+      id: result.id,
+      title: "Durable title",
+      body,
+      keywords: ["ORM", "modeling"],
+      createdAt: "2026-08-25T12:00:00.000Z",
+      cwd: "/work/one",
+    });
+    if (process.platform !== "win32") {
+      assert.equal(statSync(memoryDir(s.home)).mode & 0o777, 0o700);
+      assert.equal(statSync(result.path).mode & 0o777, 0o600);
+    }
+    assert.deepEqual(readdirSync(memoryDir(s.home)).filter((n) => n.includes(".tmp")), []);
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: explicit secrets fail closed without writing content", async () => {
+  const s = sandbox();
+  try {
+    await assert.rejects(
+      insertMemory({
+        title: "Credential",
+        body: "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.s3cr3tsignature",
+        home: s.home,
+      }),
+      /secret-shaped content/i,
+    );
+    const written = existsSync(memoryDir(s.home))
+      ? readdirSync(memoryDir(s.home)).filter((n) => n.endsWith(".json")).length : 0;
+    assert.equal(written, 0);
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: a live store lock returns a useful busy error", async () => {
+  const s = sandbox();
+  const lock = new Lock(memoryLockPath(s.home));
+  try {
+    assert.equal(lock.acquire(), true);
+    await assert.rejects(
+      insertMemory({ title: "Busy", body: "Must not be lost", home: s.home }),
+      /memory store is busy/i,
+    );
+  } finally {
+    lock.release();
+    s.clean();
+  }
+});
+
+test("manual memory: concurrent inserts produce complete unique records", async () => {
+  const s = sandbox();
+  try {
+    const records = await Promise.all(Array.from({ length: 8 }, (_, i) =>
+      insertMemory({
+        title: `Concurrent ${i}`,
+        body: `Durable body ${i}`,
+        home: s.home,
+      }),
+    ));
+    assert.equal(new Set(records.map((r) => r.id)).size, 8);
+    assert.equal(records.filter((r) => readMemory(r.path)?.schema === MEMORY_SCHEMA).length, 8);
+    assert.deepEqual(readdirSync(memoryDir(s.home)).filter((n) => n.includes(".tmp")), []);
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: an id collision cannot replace an existing record", async () => {
+  const s = sandbox();
+  const idFactory = () => "00000000-0000-4000-8000-000000000002";
+  try {
+    const original = await insertMemory({
+      title: "Original", body: "Keep this exact body.", home: s.home, idFactory,
+    });
+    await assert.rejects(
+      insertMemory({ title: "Replacement", body: "Must not overwrite.", home: s.home, idFactory }),
+      /already exists/i,
+    );
+    assert.equal(readMemory(original.path).body, "Keep this exact body.");
+    assert.deepEqual(readdirSync(memoryDir(s.home)).filter((n) => n.includes(".tmp")), []);
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: search ranks title, keywords, body, then cwd", async () => {
+  const s = sandbox();
+  try {
+    const fixtures = [
+      ["quasar title", "plain", [], "/work/a"],
+      ["keyword hit", "plain", ["quasar"], "/work/b"],
+      ["body hit", "quasar body", [], "/work/c"],
+      ["cwd hit", "plain", [], "/work/quasar"],
+    ];
+    for (const [title, body, keywords, cwd] of fixtures) {
+      await insertMemory({ title, body, keywords, cwd, home: s.home });
+    }
+    const hits = searchMemories("quasar", { home: s.home, limit: 10 });
+    assert.deepEqual(hits.map((h) => h.title),
+      ["quasar title", "keyword hit", "body hit", "cwd hit"]);
+    assert.ok(hits.every((h) => statSync(h.path).isFile()));
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: malformed and foreign JSON records are ignored", async () => {
+  const s = sandbox();
+  try {
+    mkdirSync(memoryDir(s.home), { recursive: true });
+    chmodSync(memoryDir(s.home), 0o700);
+    writeFileSync(join(memoryDir(s.home), "broken.json"), "{not-json");
+    writeFileSync(join(memoryDir(s.home), "foreign.json"), JSON.stringify({ schema: "other.v1" }));
+    assert.deepEqual(searchMemories("anything", { home: s.home }), []);
+    assert.equal(readFileSync(join(memoryDir(s.home), "broken.json"), "utf8"), "{not-json");
+  } finally {
+    s.clean();
+  }
+});
+
+test("manual memory: semantic card projection uses validated canonical records", async () => {
+  const s = sandbox();
+  try {
+    const stored = await insertMemory({
+      title: "Semantic zircon memory",
+      body: "Acyclic precedence is required.",
+      keywords: ["zircon", "acyclic"],
+      cwd: "/work/modeling",
+      home: s.home,
+    });
+    writeFileSync(join(memoryDir(s.home), "broken.json"), "{not-json");
+    const result = spawnSync("python3", [join(ROOT, "bin", "manual_memory_cards.py")], {
+      encoding: "utf8", env: { ...process.env, HOME: s.home },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const cards = JSON.parse(result.stdout);
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0][0], `memory:${stored.id}`);
+    assert.equal(cards[0][3], "Semantic zircon memory");
+    assert.match(cards[0][4], /Acyclic precedence is required/);
+    assert.match(cards[0][4], /keywords: zircon acyclic/);
+  } finally {
+    s.clean();
+  }
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1,4 +1,7 @@
-import { chmodSync, copyFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import {
+	chmodSync, copyFileSync, existsSync, mkdtempSync, mkdirSync,
+	readFileSync, writeFileSync, rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 // Protocol: MCP 2024-11-05, newline-delimited JSON over stdin/stdout.
@@ -117,4 +120,64 @@ test("mcp: unknown tool → isError with message", async () => {
 	const call = res.find((r) => r.id === 4);
 	assert.equal(call.result.isError, true);
 	assert.match(call.result.content[0].text, /unknown tool/i);
+});
+
+test("mcp: kb_insert survives server restart and is immediately searchable", async () => {
+	const home = mkdtempSync(join(tmpdir(), "heimdall-mcp-insert-"));
+	try {
+		const env = {
+			...process.env, HOME: home, GRAFT: "/nonexistent/graft", HEIMDALL_REPOS: "",
+		};
+		const body = "Occurrence-scoped steps require a durable zircon precedence constraint.\n";
+		const INSERT = {
+			jsonrpc: "2.0", id: 20, method: "tools/call",
+			params: {
+				name: "kb_insert",
+				arguments: { title: "Zircon procedure memory", body, keywords: "zircon,precedence,durable" },
+			},
+		};
+		const first = await rpc([INIT, INSERT], { env });
+		const inserted = first.find((r) => r.id === 20);
+		assert.equal(inserted.result.isError, false);
+		const receipt = JSON.parse(inserted.result.content[0].text);
+		assert.equal(receipt.searchable, true);
+		assert.equal(existsSync(receipt.path), true);
+		const record = JSON.parse(readFileSync(receipt.path, "utf8"));
+		assert.equal(record.body, body);
+		assert.deepEqual(record.keywords, ["zircon", "precedence", "durable"]);
+
+		// rpc() starts a new MCP server, proving persistence beyond process state.
+		const SEARCH = {
+			jsonrpc: "2.0", id: 21, method: "tools/call",
+			params: { name: "kb_search", arguments: { query: "zircon precedence", n: 3 } },
+		};
+		const second = await rpc([INIT, SEARCH], { env });
+		const searched = second.find((r) => r.id === 21);
+		assert.equal(searched.result.isError, false);
+		assert.match(searched.result.content[0].text, /Zircon procedure memory/);
+		assert.match(searched.result.content[0].text, new RegExp(receipt.id));
+		assert.equal(existsSync(join(home, ".heimdall", "hints.jsonl")), false);
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+});
+
+test("mcp: kb_insert returns the CLI failure reason without leaking content", async () => {
+	const home = mkdtempSync(join(tmpdir(), "heimdall-mcp-insert-error-"));
+	try {
+		const CALL = {
+			jsonrpc: "2.0", id: 22, method: "tools/call",
+			params: {
+				name: "kb_insert",
+				arguments: { title: "Credential", body: "password=do-not-store" },
+			},
+		};
+		const res = await rpc([INIT, CALL], { env: { ...process.env, HOME: home } });
+		const call = res.find((r) => r.id === 22);
+		assert.equal(call.result.isError, true);
+		assert.match(call.result.content[0].text, /secret-shaped content/i);
+		assert.doesNotMatch(call.result.content[0].text, /do-not-store/);
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
## Summary

- replace `kb_insert`'s advisory nonexistent-path hint with an append-only, machine-global JSON memory store
- make every durable insert immediately searchable through a live lexical lane, even without Graft, repositories, embeddings, or `global.db`
- include validated manual records in later semantic-index rebuilds and document the storage, privacy, and refresh contract

## Behavior

Records are written to `~/.heimdall/memories/<mem-uuid>.json` under a short-lived store lock. The write uses a same-directory temporary file, file and directory flushes, atomic rename, mode `0600`, readback validation, and an immediate ID search before returning success. Secret-shaped input is rejected without echoing it.

The MCP input schema is unchanged: `title`, `body`, and comma-separated `keywords`. Pi-style repeated `--keywords` flags and comma-separated values normalize identically. Successful CLI and MCP inserts now return JSON text containing `id`, `path`, `title`, and `searchable: true`; CLI stderr is preserved on MCP failures.

Search merges live manual-memory hits with the existing Graft and semantic lanes. `heimdall index` projects valid manual records into the local semantic database later, so insertion never waits for model loading. This also makes the existing RAM guard work on Linux/WSL via `/proc/meminfo`.

## Verification

- `npm test`: 262 passed, 0 failed
- `npm run typecheck`: passed
- `npm pack --dry-run --json`: passed; all three new runtime files are included
- isolated WSL MCP acceptance: `kb_insert -> kb_search -> server restart -> kb_search`
- isolated WSL backend-empty search: title, body, and keyword queries all returned live `STRONG` hits
- isolated WSL semantic acceptance: `heimdall index` embedded one manual record and `global.db` reported one card
- LF preservation and `git diff --check`: passed

No package version bump. No update/delete API, prompt capture, or graph redesign.

Fixes #7
